### PR TITLE
Fix button arrangement when using minimap addon

### DIFF
--- a/elements/minimap.lua
+++ b/elements/minimap.lua
@@ -1,11 +1,4 @@
 
-function MAIIsCustomMinimapLoaded()
-	if IsAddOnLoaded("SexyMap") then
-		return true
-	end
-	return false
-end
-
 local ranges = {
 	[0] = 233,
 	[1] = 200,
@@ -21,8 +14,8 @@ local maimmbtnsbliz = {}
 local iconsize = 24
 local iconborder = 6
 
-function GetMinimapShape()
-	if not MAIIsCustomMinimapLoaded() then
+if not GetMinimapShape then
+	function GetMinimapShape()
 		if MAIGV( "Minimap" .. "form" ) ~= nil then
 			if MAIGV( "Minimap" .. "form" ) == "round" or MAIGV( "nochanges" ) then
 				return 'ROUND'


### PR DESCRIPTION
When this addon is installed with a minimap replacement addon, the shape that the buttons align to is overridden. This happens if minimap.lua is loaded for any reason, even if improvements are disabled. We solve this by ensuring that we're only defining GetMinimapShape if it's not yet been defined by another addon. By checking like this, we don't need to check for every possible minimap addon by name.